### PR TITLE
loginのplaceholder名を修正

### DIFF
--- a/template/accounts/login.html
+++ b/template/accounts/login.html
@@ -32,7 +32,7 @@
                 <form method="post" action="">
                     {% csrf_token %}
                     <fieldset class="form-group">
-                        <input class="form-control " type="username" name="username" placeholder="Email" required />
+                        <input class="form-control " type="username" name="username" placeholder="Username" required />
                     </fieldset>
                     <fieldset class="form-group">
                         <input class="form-control " type="password" name="password" placeholder="Password" required/>


### PR DESCRIPTION
## 概要 
loginのplaceholder名がusernameからEmailになっており表示文言が間違っていたので修正をしております！